### PR TITLE
add images-handling file to master

### DIFF
--- a/raw_files/images-handling.xml
+++ b/raw_files/images-handling.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Title</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+     <encodingDesc><p>Basic encoding, modeling a minimally encoded document of drama. All included encoding sections were decided based on resources from the TEI Guidelines</p></encodingDesc>
+     <profileDesc>
+     </profileDesc>
+     <revisionDesc>
+        <change when="2016-11-11" who="#BJD"> added header </change>
+     </revisionDesc>
+  </teiHeader>
+  <text>
+      <body>
+         <p>TAPAS supports the display of image files in two ways:</p>
+         <p>1.<![CDATA[<figure>]]></p>
+         <p>In the following case, <![CDATA[<figure><!--1.<figure>;-->
+            <graphic url="image1.jpg"/>
+            <head>Figure Title</head>
+            <figDesc>Description of figure file</figDesc>
+         </figure>]]></p>
+         <figure>
+            <graphic url="image1.jpg"/>
+            <head>Figure Title</head>
+            <figDesc>Description of figure file</figDesc>
+         </figure>
+ 
+         <p>2.<![CDATA[@facs on <pb/>]]></p>
+         <p>In the following case, <![CDATA[<pb n="1" facs="page1.png"/>]]></p>
+         <p>@facs (facsimile) points to all or part of an image which corresponds with the content of the element.</p>
+         <pb n="1" facs="page1.png"/>
+      </body>
+  </text>
+</TEI>


### PR DESCRIPTION
this file lives in guides/templates in commons project. demonstrates
how we handle image files in reader.